### PR TITLE
fix: validate spork signer before processing

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -141,11 +141,19 @@ bool CSporkManager::IsSporkValid(const CSporkMessage& spork)
 
 bool CSporkManager::ProcessSpork(const CSporkMessage& spork)
 {
+    if (!IsSporkValid(spork)) {
+        return false;
+    }
+
+    const auto opt_keyIDSigner = spork.GetSignerKeyID();
+    if (!opt_keyIDSigner) {
+        return false;
+    }
+    const auto keyIDSigner = *opt_keyIDSigner;
+
     uint256 hash = spork.GetHash();
     std::string strLogMsg{strprintf("SPORK -- hash: %s id: %d value: %10d", hash.ToString(), spork.nSporkID,
                                     spork.nValue)};
-    assert(spork.GetSignerKeyID().has_value());
-    auto keyIDSigner = spork.GetSignerKeyID().value();
 
     {
         LOCK(cs); // make sure to not lock this together with cs_main


### PR DESCRIPTION
## Summary
- Make `CSporkManager::ProcessSpork()` self-validate before mutating spork state
- Replace the optional signer `assert()`/`.value()` path with guarded optional handling

## Validation
- `git diff --check`
- Confirmed no remaining `GetSignerKeyID().value()` / direct assert pattern in the touched spork path
- `src/test/test_dash --run_test=spork_tests` could not be run in this worktree because no test binary is present

Context: follow-up for CodeRabbit feedback on dashpay/dash#7303.
