### PR TITLE
fix: correct spork signer guard

### DIFF
--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -144,7 +144,9 @@ bool CSporkManager::ProcessSpork(const CSporkMessage& spork)
     uint256 hash = spork.GetHash();
     std::string strLogMsg{strprintf("SPORK -- hash: %s id: %d value: %10d", hash.ToString(), spork.nSporkID,
                                     spork.nValue)};
-    assert(spork.GetSignerKeyID().has_value());
+
+    if (spork.GetSignerKeyID().has_value()) return false;
+
     auto keyIDSigner = spork.GetSignerKeyID().value();
 
     {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -145,7 +145,7 @@ bool CSporkManager::ProcessSpork(const CSporkMessage& spork)
     std::string strLogMsg{strprintf("SPORK -- hash: %s id: %d value: %10d", hash.ToString(), spork.nSporkID,
                                     spork.nValue)};
 
-    if (spork.GetSignerKeyID().has_value()) return false;
+    if (!spork.GetSignerKeyID().has_value()) return false;
 
     auto keyIDSigner = spork.GetSignerKeyID().value();
 


### PR DESCRIPTION
# Summary

Fixes the inverted signer guard reported on dashpay/dash#7303.

The current branch returns `false` when `GetSignerKeyID()` succeeds, then calls
`.value()` when it failed. This changes the guard to reject only missing signer
IDs before dereferencing the optional.

## Validation

- `git diff --check knst/refactor-spork-net-processing-v2...HEAD`
- Inspected `src/spork.cpp` diff and surrounding `CSporkManager::ProcessSpork()`
  flow
- Not run: `src/test/test_dash --run_test=spork_tests` (`src/test/test_dash` is
  not built in this worktree)
