### PR TITLE
test: cover protx listdiff platform port restart regression

### DIFF
--- a/test/functional/rpc_netinfo.py
+++ b/test/functional/rpc_netinfo.py
@@ -519,6 +519,26 @@ class NetInfoTest(BitcoinTestFramework):
         assert_equal(grt_proregtx['platformP2PPort'], DEFAULT_PORT_PLATFORM_P2P)
         assert_equal(grt_proregtx['platformHTTPPort'], DEFAULT_PORT_PLATFORM_HTTP)
 
+        self.log.info("Test legacy-to-extended listdiff after restart reports valid deprecated Platform ports")
+        proupservtx_hash = self.node_two.update_mn(self, True,
+                                                   f"127.0.0.1:{self.node_two.mn.nodePort}",
+                                                   DEFAULT_PORT_PLATFORM_P2P + 1,
+                                                   DEFAULT_PORT_PLATFORM_HTTP + 1)
+        proupservtx_height = self.node_simple.getrawtransaction(proupservtx_hash, True)['height']
+
+        # Restart the deprecated-RPC node to force deterministic MN state through the serialized
+        # snapshot/diff path. This caught a regression where ExtAddr Platform addresses were correct
+        # but the deprecated scalar ports in protx listdiff were reported as 0.
+        self.restart_node(self.node_simple.index)
+        self.reconnect_nodes()
+
+        protx_listdiff_rpc = self.node_simple.protx('listdiff', proupservtx_height - 1, proupservtx_height)
+        protx_listdiff_rpc = self.extract_from_listdiff(protx_listdiff_rpc, self.node_two.mn.proTxHash)
+        self.check_netinfo_fields(protx_listdiff_rpc['addresses'], self.node_two.mn.nodePort,
+                                  DEFAULT_PORT_PLATFORM_HTTP + 1, DEFAULT_PORT_PLATFORM_P2P + 1)
+        assert_equal(protx_listdiff_rpc['platformP2PPort'], DEFAULT_PORT_PLATFORM_P2P + 1)
+        assert_equal(protx_listdiff_rpc['platformHTTPPort'], DEFAULT_PORT_PLATFORM_HTTP + 1)
+
         # Destroy and re-register node as blank
         self.node_two.destroy_mn(self)
         self.reconnect_nodes()


### PR DESCRIPTION
## Issue being fixed or feature implemented

Adds regression coverage for the `protx listdiff` restart/snapshot edge case fixed by dashpay/dash#7360.

When an Evo masternode moves from legacy Platform port fields to ExtAddr `netInfo`, a restarted node may rebuild the deterministic MN diff from serialized state. The regression test verifies that deprecated `platformP2PPort` / `platformHTTPPort` fields in `protx listdiff` remain consistent with the valid Platform addresses instead of reporting `0`.

## What was done?

Updated `test/functional/rpc_netinfo.py` to:

- update a pre-v24 EvoNode from legacy Platform ports to ExtAddr Platform addresses after v24 activation
- restart the `-deprecatedrpc=service` node to exercise the serialized snapshot/diff path
- call `protx listdiff` over the ProUpServTx block
- assert both `addresses` and deprecated scalar Platform port fields report the expected non-zero ports

## How Has This Been Tested?

Built locally on macOS arm64 with:

```bash
./autogen.sh
./configure --without-gui --disable-bench --disable-fuzz-binary
make -j$(sysctl -n hw.ncpu)
```

Validation:

```bash
python3 -m py_compile test/functional/rpc_netinfo.py
git diff --check -- test/functional/rpc_netinfo.py
python3 test/functional/test_runner.py rpc_netinfo.py
```

`rpc_netinfo.py` passed.

Pre-PR review gate:

```bash
code-review dashpay/dash knst/fix-v24-extdiff test/pr7360-listdiff-regression "Add a functional regression test covering legacy-to-ExtAddr protx listdiff deprecated Platform ports after restart/snapshot"
```

Result: `ship`.

## Breaking Changes

None. Test-only change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
